### PR TITLE
Don't downscale images in SD Upscale mode

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -189,10 +189,6 @@ async def f_img2img(req: Img2ImgRequest):
     if script and script.title() == "SD upscale":
         # in SD upscale mode, width & height determines tile size
         width = height = req.base_size
-        # SD scales by 2x image size; we alr scaled up in Krita so downscale here
-        image = image.resize((image.width // 2, image.height // 2))
-        if mask:
-            mask = mask.resize((image.width // 2, image.height // 2))
     else:
         width, height = sddebz_highres_fix(
             req.base_size, req.max_size, orig_width, orig_height


### PR DESCRIPTION
SD Upscale by itself doesn't increase the size of a picture. If we use a prescaler though, the prescaler will increase size x2. Anyway image will be downscaled back to initial size by the following code after calling img2img function. 
```
    resized_images = [
        modules.images.resize_image(0, image, orig_width, orig_height)
        for image in output_images
    ]
```

If we downscale image before calling sd upscale script, we lose too much information. It's better to not downscale image and work on native resolution whereever possible.

I personally think that sd upscale should not be used with a prescaler. It's not a core part of algorithm and neural upscalers will only slow down processing. Using sd upscale without prescaler essentialy enables user to work in native resolution without resizing source image at all. It's a really good way to add details and is superior to highres fix from webui in my opinion.

If user wants to increase resolution, it can be done with default Krita image resize dialog and Lanczos3 upscaler for example. Maybe it's worth properly implementing interface for webui upscaling with ESRGAN and friends, which would include rezising image in Krita instead of downscaling it to match initial dimension.