### PR TITLE
Don't swap multiline prompts to comma-separated prompts

### DIFF
--- a/frontends/krita/krita_diff/utils.py
+++ b/frontends/krita/krita_diff/utils.py
@@ -9,9 +9,8 @@ from .config import Config
 
 
 def fix_prompt(prompt: str):
-    """Multiline tokens -> comma-separated tokens. Replace empty prompts with None."""
-    joined = ", ".join(filter(bool, [x.strip() for x in prompt.splitlines()]))
-    return joined if joined != "" else None
+    """Replace empty prompts with None."""
+    return prompt if prompt != "" else None
 
 
 def get_ext_key(ext_type: str, ext_name: str, index: int = None):


### PR DESCRIPTION
So when I wrote this code, webui didn't really support multiline prompts. Now it does and this code is kind of obsolete. It also kills reproducibility. That means, if you copy-paste prompt, negative prompt and all other settings and seed into webui, you will not get the same image.

I believe it's better to just remove this "\n" -> ", " substitution, so people will reliably get the same images from Krita and from webui.

I didn't remove fix_prompt function completely because I'm not really sure that nothing depends on "None" here.