### PR TITLE
Canvas Resizing after Image Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ A: Unfortunately no, all plugins so far have different APIs. The official API is
 
 ## UI Changelog
 
+### 2022-11-15
+
+- Scripts/features that increase the image size (Simple upscaling, SD upscaling, Outpaint Mk 2, etc) will now expand the canvas when image generation is complete **only if** _there is no active selection_.
+  - If there is a selection, the image will be scaled to fit the selection region.
+  - Using Ctrl+A to select the entire image is considered an active selection!
+
+
 ### 2022-11-08
 
 - Inpainting is finally 100% fixed! No more weird borders. Blur works properly.


### PR DESCRIPTION
This fixes #11. All scripts/features that increase the image size (i.e. simple upscaling, SD upscaling, the outpainting scripts), will now increase the canvas size once image generation is complete **unless** there is an active selection. If there is, the image will be resized to fit that selection on the client-side rather than backend because the backend doesn't know what the selection is. This is an exception rather than a rule, because without additional libraries, QImage is very limited in its scaling functionality (only has nearest or bilinear scaling), so scaling on the backend is still preferred for now.