### PR TITLE
Add VAE and CLIP Skip selections to the SD Common Options tab.

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -95,6 +95,7 @@ async def get_state():
         "scripts_img2img": get_scripts_metadata(True),
         "face_restorers": [model.name() for model in shared.face_restorers],
         "sd_models": modules.sd_models.checkpoint_tiles(),  # yes internal API has spelling error
+        "sd_vaes": ["None", "Automatic" ] + (list(modules.sd_vae.vae_dict))
     }
 
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -26,6 +26,8 @@ class BaseOptions(BaseModel):
 class GenerationOptions(BaseModel):
     sd_model: str = "model.ckpt"
     """Model to use for generation."""
+    sd_vae: str = "Automatic"
+    """VAE to use for generation."""
     script: str = "None"
     """Which script to use."""
     script_args: list = Field(default_factory=list)

--- a/backend/config.py
+++ b/backend/config.py
@@ -28,6 +28,10 @@ class GenerationOptions(BaseModel):
     """Model to use for generation."""
     sd_vae: str = "Automatic"
     """VAE to use for generation."""
+
+    clip_skip: int = 1
+    """CLIP layers to skip during generation."""
+
     script: str = "None"
     """Which script to use."""
     script_args: list = Field(default_factory=list)

--- a/backend/structs.py
+++ b/backend/structs.py
@@ -71,6 +71,8 @@ class ConfigResponse(PluginOptions):
     """List of available face restorers."""
     sd_models: List[str]
     """List of available models."""
+    sd_vaes: List[str]
+    """List of available VAEs."""
 
 
 class ImageResponse(BaseModel):

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -89,6 +89,9 @@ def prepare_backend(opt: BaseModel):
         shared.opts.sd_vae = opt.sd_vae
         modules.sd_vae.reload_vae_weights()
 
+    if hasattr(opt, "clip_skip"):
+        shared.opts.CLIP_stop_at_last_layers = opt.clip_skip
+
     if hasattr(opt, "upscaler_name"):
         shared.opts.upscaler_for_img2img = opt.upscaler_name
 

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -85,6 +85,10 @@ def prepare_backend(opt: BaseModel):
         shared.opts.sd_model_checkpoint = opt.sd_model
         modules.sd_models.reload_model_weights(shared.sd_model)
 
+    if hasattr(opt, "sd_vae"):
+        shared.opts.sd_vae = opt.sd_vae
+        modules.sd_vae.reload_vae_weights()
+
     if hasattr(opt, "upscaler_name"):
         shared.opts.upscaler_for_img2img = opt.upscaler_name
 

--- a/frontends/krita/krita_diff/client.py
+++ b/frontends/krita/krita_diff/client.py
@@ -221,6 +221,7 @@ class Client(QObject):
         params = dict(
             sd_model=self.cfg("sd_model", str),
             sd_vae=self.cfg("sd_vae", str),
+            clip_skip=self.cfg("clip_skip", int),
             batch_count=self.cfg("sd_batch_count", int),
             batch_size=self.cfg("sd_batch_size", int),
             base_size=self.cfg("sd_base_size", int),

--- a/frontends/krita/krita_diff/client.py
+++ b/frontends/krita/krita_diff/client.py
@@ -220,6 +220,7 @@ class Client(QObject):
         # its fine to stuff extra stuff here; pydantic will shave off irrelevant params
         params = dict(
             sd_model=self.cfg("sd_model", str),
+            sd_vae=self.cfg("sd_vae", str),
             batch_count=self.cfg("sd_batch_count", int),
             batch_size=self.cfg("sd_batch_size", int),
             base_size=self.cfg("sd_base_size", int),
@@ -246,6 +247,7 @@ class Client(QObject):
                 assert len(obj["samplers_img2img"]) > 0
                 assert len(obj["face_restorers"]) > 0
                 assert len(obj["sd_models"]) > 0
+                assert len(obj["sd_vaes"]) > 0
                 assert len(obj["scripts_txt2img"]) > 0
                 assert len(obj["scripts_img2img"]) > 0
             except:
@@ -267,6 +269,7 @@ class Client(QObject):
             self.cfg.set("inpaint_script_list", list(obj["scripts_img2img"].keys()))
             self.cfg.set("face_restorer_model_list", obj["face_restorers"])
             self.cfg.set("sd_model_list", obj["sd_models"])
+            self.cfg.set("sd_vae_list", ["Automatic", "None"] + obj["sd_vaes"])
 
             # extension script cfg
             obj["scripts_inpaint"] = obj["scripts_img2img"]

--- a/frontends/krita/krita_diff/defaults.py
+++ b/frontends/krita/krita_diff/defaults.py
@@ -63,6 +63,8 @@ class Defaults:
 
     sd_model_list: List[str] = field(default_factory=lambda: [ERROR_MSG])
     sd_model: str = "model.ckpt"
+    sd_vae_list: List[str] = field(default_factory=lambda: [ERROR_MSG])
+    sd_vae: str = "Automatic"
     sd_batch_size: int = 1
     sd_batch_count: int = 1
     sd_base_size: int = 512

--- a/frontends/krita/krita_diff/defaults.py
+++ b/frontends/krita/krita_diff/defaults.py
@@ -65,6 +65,7 @@ class Defaults:
     sd_model: str = "model.ckpt"
     sd_vae_list: List[str] = field(default_factory=lambda: [ERROR_MSG])
     sd_vae: str = "Automatic"
+    clip_skip: int = 1
     sd_batch_size: int = 1
     sd_batch_count: int = 1
     sd_base_size: int = 512

--- a/frontends/krita/krita_diff/pages/common.py
+++ b/frontends/krita/krita_diff/pages/common.py
@@ -26,6 +26,11 @@ class SDCommonPage(QWidget):
             script.cfg, "sd_vae_list", "sd_vae", label="VAE:"
         )
 
+        # Clip skip
+        self.clip_skip_layout = QSpinBoxLayout(
+            script.cfg, "clip_skip", label="Clip skip:", min=1, max=12, step=1
+        )
+
         # batch size & count
         self.batch_count_layout = QSpinBoxLayout(
             script.cfg, "sd_batch_count", label="Batch count:", min=1, max=9999, step=1
@@ -89,6 +94,7 @@ class SDCommonPage(QWidget):
         layout.addLayout(checkboxes_layout)
         layout.addLayout(self.sd_model_layout)
         layout.addLayout(self.sd_vae_layout)
+        layout.addLayout(self.clip_skip_layout)
         layout.addLayout(batch_layout)
         layout.addLayout(size_layout)
         layout.addWidget(self.interrupt_btn)
@@ -99,6 +105,7 @@ class SDCommonPage(QWidget):
     def cfg_init(self):
         self.sd_model_layout.cfg_init()
         self.sd_vae_layout.cfg_init()
+        self.clip_skip_layout.cfg_init()
         self.batch_count_layout.cfg_init()
         self.batch_size_layout.cfg_init()
         self.base_size_layout.cfg_init()
@@ -114,6 +121,7 @@ class SDCommonPage(QWidget):
     def cfg_connect(self):
         self.sd_model_layout.cfg_connect()
         self.sd_vae_layout.cfg_connect()
+        self.clip_skip_layout.cfg_connect()
         self.batch_count_layout.cfg_connect()
         self.batch_size_layout.cfg_connect()
         self.base_size_layout.cfg_connect()

--- a/frontends/krita/krita_diff/pages/common.py
+++ b/frontends/krita/krita_diff/pages/common.py
@@ -21,6 +21,11 @@ class SDCommonPage(QWidget):
             script.cfg, "sd_model_list", "sd_model", label="SD model:"
         )
 
+        # VAE list
+        self.sd_vae_layout = QComboBoxLayout( 
+            script.cfg, "sd_vae_list", "sd_vae", label="VAE:"
+        )
+
         # batch size & count
         self.batch_count_layout = QSpinBoxLayout(
             script.cfg, "sd_batch_count", label="Batch count:", min=1, max=9999, step=1
@@ -83,6 +88,7 @@ class SDCommonPage(QWidget):
         layout.addLayout(self.codeformer_weight_layout)
         layout.addLayout(checkboxes_layout)
         layout.addLayout(self.sd_model_layout)
+        layout.addLayout(self.sd_vae_layout)
         layout.addLayout(batch_layout)
         layout.addLayout(size_layout)
         layout.addWidget(self.interrupt_btn)
@@ -92,6 +98,7 @@ class SDCommonPage(QWidget):
 
     def cfg_init(self):
         self.sd_model_layout.cfg_init()
+        self.sd_vae_layout.cfg_init()
         self.batch_count_layout.cfg_init()
         self.batch_size_layout.cfg_init()
         self.base_size_layout.cfg_init()
@@ -106,6 +113,7 @@ class SDCommonPage(QWidget):
 
     def cfg_connect(self):
         self.sd_model_layout.cfg_connect()
+        self.sd_vae_layout.cfg_connect()
         self.batch_count_layout.cfg_connect()
         self.batch_size_layout.cfg_connect()
         self.base_size_layout.cfg_connect()


### PR DESCRIPTION
Hopefully did it right this time...Since I'm frequently switching between models that require different VAEs and CLIP skip settings to work properly, I thought it might be useful to add selectors for these to the SD Common Options tab in the extension. This could be a partial fix for #16 , although it's not a full model settings preset system as you mentioned there.